### PR TITLE
Route bonuses to option templates to instances

### DIFF
--- a/camp/character/forms.py
+++ b/camp/character/forms.py
@@ -74,31 +74,37 @@ class FeatureForm(forms.Form):
                 label=f"New {c.rank_name_labels[0].title()}",
             )
 
+    def selected_option(self) -> str | None:
+        if "option" in self.cleaned_data and self.cleaned_data["option"] != "__other__":
+            return self.cleaned_data["option"]
+        if "option_freeform" in self.cleaned_data:
+            return self.cleaned_data["option_freeform"]
+        return None
+
     def _make_option_field(self, c: FeatureController):
-        if not c.option and c.option_def:
+        if not c.option and (option_def := c.option_def):
             available = c.available_options
-            if c.option_def.freeform:
-                if c.option_def.freeform:
-                    if available:
-                        widget = DatalistTextInput(available)
-                        help = f"This {c.type_name.lower()} takes a custom option. Enter it here. Suggestions: {', '.join(available)}."
-                    else:
-                        widget = forms.TextInput
-                        help = f"This {c.type_name.lower()} takes a custom option. Enter it here."
-                    self.fields["option"] = forms.CharField(
-                        max_length=100,
-                        label="Option",
-                        widget=widget,
-                        help_text=help,
-                    )
-            elif available:
-                # If the option has both choices *and* freeform. The choices are basically
-                # just a suggestion, so we'll let the user enter whatever they want and provide a
-                # datalist.
+            if available:
+                if d := option_def.descriptions:
+                    options = [(a, f"{a}: {d[a]}" if a in d else a) for a in available]
+                else:
+                    options = [(a, a) for a in available]
+                help_text = "Select an option."
+                if option_def.freeform:
+                    options.append(("__other__", "Other"))
+                    help_text = "Select an option, or Other to enter a custom option."
                 self.fields["option"] = forms.ChoiceField(
-                    choices=[(a, a) for a in available],
+                    widget=forms.RadioSelect,
+                    choices=options,
                     label="Options",
-                    help_text="Select an option. If you don't see the option you want, ask plot staff.",
+                    help_text=help_text,
+                )
+            if option_def.freeform:
+                self.fields["option_freeform"] = forms.CharField(
+                    max_length=100,
+                    label="Custom Option",
+                    required=not (available),
+                    help_text=f"This {c.type_name.lower()} takes a custom option. Enter it here.",
                 )
 
 

--- a/camp/character/forms.py
+++ b/camp/character/forms.py
@@ -42,6 +42,9 @@ class FeatureForm(forms.Form):
         if available == 1 and c.definition.ranks == 1:
             # The only thing that can happen here is purchasing 1 rank, so don't
             # bother with a choice field.
+            if c.unused_bonus > 0:
+                self.button_label = "Get!"
+                self.button_level = "success"
             return
         if available > 0 and c.definition.ranks != 1:
             next_value = c.next_value

--- a/camp/character/templates/character/character_detail.html
+++ b/camp/character/templates/character/character_detail.html
@@ -93,9 +93,9 @@
                           {% endif %}
                         {% endif %}
 
-                        {% if f.has_available_choices %}
-                        <span class="badge bg-primary">Choices Available</span>
-                        {% endif %}
+                        {% for level, badge in f.badges %}
+                        <span class="badge bg-{{level}}">{{badge}}</span>
+                        {% endfor %}
                     </a>
                     {% if f.subfeatures %}
                     <ul>

--- a/camp/character/templates/character/feature_form.html
+++ b/camp/character/templates/character/feature_form.html
@@ -134,3 +134,33 @@
 <a role="button" class="btn btn-secondary" href="{% url 'character-detail' character.id %}">Back</a>
 
 {% endblock %}
+
+{% block javascript %}
+<script>
+    /* If we have both radio buttons and a freeform option, disable the freeform option unless the "Other" radio button is selected. */
+    const other_radio = document.querySelector('input[type="radio"][name="option"][value="__other__"]');
+    const option_freeform = document.querySelector("#id_option_freeform");
+    if (other_radio && option_freeform) {
+        if (other_radio.checked) {
+            option_freeform.disabled = false;
+            option_freeform.required = true;
+        } else {
+            option_freeform.disabled = true;
+            option_freeform.required = false;
+        }
+        other_radio.addEventListener("change", function() {
+            if (other_radio.checked) {
+                option_freeform.disabled = false;
+                option_freeform.required = true;
+            }
+        });
+        document.querySelectorAll('input[type="radio"][name="option"]:not([value="__other__"])').forEach(function(radio) {
+            radio.addEventListener("change", function() {
+                option_freeform.disabled = true;
+                option_freeform.required = false;
+                option_freeform.value = "";
+            });
+        });
+    }
+</script>
+{% endblock %}

--- a/camp/character/templates/character/feature_form.html
+++ b/camp/character/templates/character/feature_form.html
@@ -32,6 +32,10 @@
 {% endif %}
 
 {% if purchase_form %}
+{% if feature.unused_bonus > 0 %}
+<p>You have {{ feature.unused_bonus }} unused bonus rank(s). Your next purchase is free.</p>
+{% endif %}
+
 <form method="post" id="purchaseForm">
     {% csrf_token %}
         {{ purchase_form | crispy }}
@@ -70,7 +74,7 @@
 <h3>Granted Features</h3>
 <ul>
 {% for subfeat in feature.granted_features %}
-<li><a href="{% url 'character-feature-view' character.id subfeat.id %}">{{ subfeat.formal_name }}</a></li>
+<li><a href="{% url 'character-feature-view' character.id subfeat.full_id %}">{{ subfeat.formal_name }}</a></li>
 {% endfor %}
 </ul>
 {% endif %}

--- a/camp/character/views.py
+++ b/camp/character/views.py
@@ -234,7 +234,7 @@ def _try_apply_purchase(
         rm = RankMutation(
             id=expr.prop,
             ranks=ranks,
-            option=pf.cleaned_data.get("option") or expr.option,
+            option=pf.selected_option() or expr.option,
         )
         try:
             if result := _apply_mutation(rm, sheet, controller):

--- a/camp/character/views.py
+++ b/camp/character/views.py
@@ -302,15 +302,15 @@ def _features(
                 priority=controller.display_priority(feat.feature_type),
             )
         group = by_type[feat.feature_type]
-        if feat.is_option_template:
+        if feat.should_show_in_list:
+            if not feat.internal:
+                group.taken.append(feat)
+        elif feat.is_option_template:
             # Option templates should only appear in the available list,
             # and only if another option is available.
             if feat.can_take_new_option:
                 group.add_available(feat)
             # Otherwise, we don't care about them.
-        elif feat.value > 0:
-            if not feat.internal:
-                group.taken.append(feat)
         else:
             group.add_available(feat)
     groups: list[FeatureGroup] = list(t for t in by_type.values() if t)

--- a/camp/engine/rules/base_models.py
+++ b/camp/engine/rules/base_models.py
@@ -368,6 +368,7 @@ class OptionDef(BaseModel):
     requires: dict[str, Requirements] | None = None
     inherit: str | None = None
     multiple: bool | pydantic.PositiveInt = True
+    descriptions: dict[str, str] | None = None
 
 
 class BaseFeatureDef(BaseModel):

--- a/camp/engine/rules/tempest/controllers/feature_controller.py
+++ b/camp/engine/rules/tempest/controllers/feature_controller.py
@@ -118,7 +118,7 @@ class FeatureController(base_engine.BaseFeatureController):
     def next_cost(self) -> int:
         if self.unused_bonus > 0:
             return 0
-        grants = self.granted_ranks
+        grants = 0 if self.is_option_template else self.granted_ranks
         return self._cost_for(self.paid_ranks + 1, grants) - self._cost_for(
             self.paid_ranks, grants
         )
@@ -474,9 +474,8 @@ class FeatureController(base_engine.BaseFeatureController):
         available = self._currency_balance()
         if available is None:
             return _NO_PURCHASE
-        currency_delta = (
-            self._cost_for(self.paid_ranks + value, self.granted_ranks) - self.cost
-        )
+        grants = 0 if self.is_option_template else self.granted_ranks
+        currency_delta = self._cost_for(self.paid_ranks + value, grants) - self.cost
         if available < currency_delta:
             return Decision(
                 success=False,

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-1.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-1.yaml
@@ -1,6 +1,13 @@
-name: Draconic Heritage
+name: Draconic Heritage I
 cost: 2
 creation_only: true
+option:
+  multiple: false
+  values:
+    - Lightning
+    - Flame
+    - Ice
+    - Acid
 description: |
   The character has dragon ancestors. This manifests in a number of ways and the character’s
   draconic blood can express itself more as the character rises in level. The character should

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-2.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-2.yaml
@@ -3,6 +3,8 @@ cost: 2
 requires:
   - level:5
   - draconic-heritage-1
+option:
+  inherit: draconic-heritage-1
 description: |
   The character can use a breath weapon once per Long Rest. As a Verbal, this will do four damage,
   plus the number of Draconic Heritage perks taken, to one target that the character could strike

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-3.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-3.yaml
@@ -3,5 +3,7 @@ cost: 2
 requires:
   - level:10
   - draconic-heritage-2
+option:
+  inherit: draconic-heritage-1
 description: |
   The character may choose to Resist effects from their chosen Element. They may do this at will.

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-4.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-4.yaml
@@ -3,6 +3,8 @@ cost: 2
 requires:
   - level:15
   - draconic-heritage-3
+option:
+  inherit: draconic-heritage-1
 description: |
   The dragon’s natural magical resistance expresses itself. After completing a Short Rest, the
   character automatically gains a Protect against Packets. This Protect lasts until it is used

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-5.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-5.yaml
@@ -3,5 +3,7 @@ cost: 2
 requires:
   - level:20
   - draconic-heritage-4
+option:
+  inherit: draconic-heritage-1
 description: |
   The character may choose to Counter any Effects, or Damage, of the chosen Accent that they take. They may do this at-will.

--- a/camp/tempest/v1/ruleset.yaml
+++ b/camp/tempest/v1/ruleset.yaml
@@ -267,9 +267,11 @@ default_flags:
     - Cloth
     - Magic
     - Materia
-  # Used in Profession - Apprentice
+  # Used in Profession - Apprentice and Chronic Hobbyist
   Professions:
     - Soldier
+    - Mercenary
+    - Scout
     - Hunter
     - Sailor
     - Wagoneer
@@ -281,7 +283,10 @@ default_flags:
     - Herbalist
     - Undertaker
     - Executioner
+    - Lumberjack
     - Merchant
+    - Miner
+    - Quarrier
     - Charlatan
     - Chirurgeon
     - Teacher

--- a/camp/tempest/v1/skills/scholar/lore.yaml
+++ b/camp/tempest/v1/skills/scholar/lore.yaml
@@ -11,3 +11,22 @@ option:
     - Religious
     - Shadow
     - Undead
+  descriptions:
+    Arcane: |
+      Magic and its uses, magical tools and applications, magical constructs, spell creation.
+    Historical: |
+      Major events, dates, interactions of events and casualties, historical figures.
+    Nature: |
+      Animals and their habits, woodcraft, myths and legends about the natural world, plants and their uses. This also includes creatures and monsters that are native to the region.
+    Noble: |
+      Etiquette, titles, traditions and customs, noble names and families, history of ruling families, especially the Great Houses.
+    Planar: |
+      Planar geography, the natures of different planes and their interactions, moving between planes, and the ruling creatures of those planes.
+    Religious: |
+      Gods and their domains, afterlife beliefs, church traditions, cultural attitudes towards the gods.
+    Shadow: |
+      Underworld and underworld etiquette, power players, customs and mores, connections, illicit substances and their uses, cons and crimes.
+    Undead: |
+      Undead in their various forms, their powers and characteristics. Major undead players in the area or setting.
+description: |
+  The character has learned about a specific area of study, with each area of study considered a separate skill. Lore confers a level of knowledge that is both deep and detailed, although not quite encyclopedic, and represents a long commitment to education on the topic. The more granular the area of knowledge, the more specific the knowledge is likely to be. The following is a list of suggested areas of study. Players should feel free to choose ones not in this list as long as they are appropriate to the setting.

--- a/camp/tempest/v1/skills/trade/profession-journeyman.yaml
+++ b/camp/tempest/v1/skills/trade/profession-journeyman.yaml
@@ -1,5 +1,5 @@
 name: Profession - Journeyman
-cost: 1
+cost: 2
 # TODO(#16): Add tracking to record the income
 requires: profession-apprentice
 option:

--- a/camp/tempest/v1/skills/trade/profession-master.yaml
+++ b/camp/tempest/v1/skills/trade/profession-master.yaml
@@ -1,10 +1,10 @@
 name: Profession - Master
-cost: 1
+cost: 3
 # TODO(#16): Add tracking to record the income
 requires: profession-journeyman
 option:
   multiple: false
-  inherit: profession-journeyman
+  inherit: profession-apprentice
 description: |
   The character has mastered her chosen profession. She can perform the most
   complicated tasks and has a deep knowledge of lore associated with that mastery.

--- a/tests/camp/tempest_test/test_character.py
+++ b/tests/camp/tempest_test/test_character.py
@@ -15,7 +15,7 @@ def test_serialization_flow(engine: TempestEngine, character: TempestCharacter):
     assert character.apply("basic-flaw")
     assert character.apply("basic-perk")
     assert character.apply("specific-options+One")
-    assert character.apply("inherited-option+One")
+    assert character.apply("inherited-option")
     assert character.meets_requirements("martial:5")
     assert character.meets_requirements("divine:5")
 
@@ -35,6 +35,6 @@ def test_serialization_flow(engine: TempestEngine, character: TempestCharacter):
     assert loaded.meets_requirements("basic-flaw")
     assert loaded.meets_requirements("basic-perk")
     assert loaded.meets_requirements("specific-options+One")
-    assert loaded.meets_requirements("inherited-option+One")
+    assert loaded.meets_requirements("inherited-option")
 
     assert data == loaded.dump_dict()

--- a/tests/camp/tempest_test/test_skills.py
+++ b/tests/camp/tempest_test/test_skills.py
@@ -184,46 +184,14 @@ def test_inherited_option_skill(starter: TempestCharacter):
     assert not starter.can_purchase("inherited-option+One")
 
     assert starter.apply("specific-options+One")
-    assert starter.apply("specific-options+Two")
 
-    assert starter.can_purchase("inherited-option").needs_option
-    assert starter.options_values_for_feature(
-        "inherited-option", exclude_taken=True
-    ) == {"One", "Two"}
-    assert starter.can_purchase("inherited-option+One")
-    assert starter.apply("inherited-option+One")
-    assert starter.options_values_for_feature(
-        "inherited-option", exclude_taken=True
-    ) == {"Two"}
-    assert starter.apply("inherited-option+Two")
+    assert starter.can_purchase("inherited-option")
+    assert starter.apply("inherited-option")
+    inherited = starter.feature_controller("inherited-option")
+    assert inherited.option == "One"
 
     # After purchasing all available options, the skill no longer registers as purchasable
     rd = starter.can_purchase("inherited-option")
-    assert not rd.success
-    assert not rd.needs_option
-
-
-def test_inherited_option_with_ranks(starter: TempestCharacter):
-    """If the inherited option feature is specified with a rank value, values from that feature
-    are only valid choices if they have that many ranks.
-    """
-    starter.awarded_cp = 5
-    assert starter.apply("specific-options+One")
-    assert starter.apply("specific-options+Two:4")
-
-    assert starter.can_purchase("inherited-with-ranks").needs_option
-    assert starter.options_values_for_feature(
-        "inherited-with-ranks", exclude_taken=True
-    ) == {"Two"}
-    assert not starter.can_purchase("inherited-with-ranks+One")
-    assert starter.can_purchase("inherited-with-ranks+Two")
-    assert not starter.apply("inherited-with-ranks+One")
-    assert starter.apply("inherited-with-ranks+Two")
-    assert not starter.options_values_for_feature(
-        "inherited-with-ranks", exclude_taken=True
-    )
-
-    rd = starter.can_purchase("inherited-with-ranks")
     assert not rd.success
     assert not rd.needs_option
 


### PR DESCRIPTION
Fixes #76

- Option Grant Router
- Inherited options no longer surface as actual options.
- Displays "default" option values as radio buttons, along with a freeform field.
