### PR TITLE
Display cost (or award) values on overview.

### DIFF
--- a/camp/character/templates/character/character_detail.html
+++ b/camp/character/templates/character/character_detail.html
@@ -91,13 +91,6 @@
                 <li class="list-group-item">
                     <a href="{% url 'character-feature-view' character.id f.full_id %}">
                         {{ f.feature_list_name }}
-                        {% if f.can_increase %}
-                        ⇧
-                          {% if f.purchase_cost_string %}
-                            ({{ f.purchase_cost_string }})
-                          {% endif %}
-                        {% endif %}
-
                         {% for level, badge in f.badges %}
                         <span class="badge bg-{{level}}">{{badge}}</span>
                         {% endfor %}
@@ -108,13 +101,6 @@
                         <li>
                             <a href="{% url 'character-feature-view' character.id sf.full_id%}">
                                 {{ sf.formal_name }}
-                                {% if sff.can_increase %}
-                                ⇧
-                                  {% if sf.purchase_cost_string %}
-                                    ({{ sf.purchase_cost_string }})
-                                  {% endif %}
-                                {% endif %}
-
                                 {% for level, badge in sf.badges %}
                                 <span class="badge bg-{{level}}">{{badge}}</span>
                                 {% endfor %}

--- a/camp/character/templates/character/feature_form.html
+++ b/camp/character/templates/character/feature_form.html
@@ -143,12 +143,6 @@
     <li class="list-group-item">
         <a href="{% url 'character-feature-view' character.id f.full_id %}">
             {{ f.formal_name }}
-            {% if f.can_increase %}
-            ⇧
-            {% if f.purchase_cost_string %}
-                ({{ f.purchase_cost_string }})
-            {% endif %}
-            {% endif %}
             {% for level, badge in f.badges %}
             <span class="badge bg-{{level}}">{{badge}}</span>
             {% endfor %}
@@ -160,12 +154,9 @@
             <li>
                 <a href="{% url 'character-feature-view' character.id sf.full_id%}">
                     {{ sf.formal_name }}
-                    {% if sff.can_increase %}
-                    ⇧
-                        {% if sf.purchase_cost_string %}
-                        ({{ sf.purchase_cost_string }})
-                        {% endif %}
-                    {% endif %}
+                    {% for level, badge in sf.badges %}
+                    <span class="badge bg-{{level}}">{{badge}}</span>
+                    {% endfor %}
                 </a>
             </li>
             {% endfor %}

--- a/camp/engine/rules/tempest/controllers/breed_controller.py
+++ b/camp/engine/rules/tempest/controllers/breed_controller.py
@@ -360,7 +360,15 @@ class BreedChallengeController(feature_controller.FeatureController):
                     award += mod
         return max(award * self.paid_ranks, 0)
 
+    @property
+    def cost_string(self) -> str | None:
+        if (cost := self.award_bp) or self.paid_ranks:
+            return self.purchase_cost_string(cost=cost)
+        return None
+
     def purchase_cost_string(self, ranks: int = 1, cost: int | None = None) -> str:
+        if cost is not None:
+            return f"+{cost} BP"
         match self.definition.award:
             case int():
                 return f"+{self.definition.award} BP"

--- a/camp/engine/rules/tempest/controllers/flaw_controller.py
+++ b/camp/engine/rules/tempest/controllers/flaw_controller.py
@@ -161,7 +161,15 @@ class FlawController(feature_controller.FeatureController):
         self.reconcile()
         return Decision.OK
 
+    @property
+    def cost_string(self) -> str | None:
+        if (cost := self.award_cp) or self.paid_ranks:
+            return self.purchase_cost_string(cost=cost)
+        return None
+
     def purchase_cost_string(self, ranks: int = 1, cost: int | None = None) -> str:
+        if cost is not None:
+            return f"+{cost} CP"
         match self.definition.award:
             case int():
                 return f"+{self.definition.award} CP"


### PR DESCRIPTION
These are displayed via a badge. For items that normally would display a cost but are free, no badge will be displayed. For items that are normally "free" like powers and spells, no badge will be displayed unless the feature is granted, in which case a "Granted" badge will be shown.

This should probably largely address #62 and #65.