### PR TITLE
Character sheet printing enhancements.

### DIFF
--- a/camp/character/templates/character/character_base.html
+++ b/camp/character/templates/character/character_base.html
@@ -7,11 +7,14 @@
 {% endblock %}
 
 {% block body_title %}
+<div {% if request.resolver_match.url_name != 'character-detail' %}class="d-print-none"{% endif %}>
 <a class="link-body-emphasis link-underline-opacity-0 link-underline-opacity-100-hover" href="{% url 'character-detail' character.id %}">{{ character }}</a>
+<div>
 {% endblock %}
 
 {% block precontent %}
 
+<div {% if request.resolver_match.url_name != 'character-detail' %}class="d-print-none"{% endif %}>
 <h4>{% if character.campaign %}
     Campaign: {{character.campaign}}
     {% else %}
@@ -47,6 +50,10 @@
     <li class="list-group-item"><span class="align-middle">LP: {% get 'lp' %}</span></li>
     <li class="list-group-item"><span class="align-middle">Spikes: {% get 'spikes' %}</span></li>
     {% block extra_header_bar %}{% endblock %}
+    <li class="list-group-item d-print-none"><span class="align-middle">
+        <a role="button" class="link-light link-underline-opacity-0" href="#" onclick="print()">
+            <i class="bi bi-printer"></i></a></span>
+    </li>
 </ul>
 {% if controller.sphere_data %}
 {# TODO: Make this look better. #}
@@ -57,6 +64,7 @@
     </li>
     {% endfor %}
 </ul>
+</div>
 
 {% endif %}
 

--- a/camp/character/templates/character/character_detail.html
+++ b/camp/character/templates/character/character_detail.html
@@ -4,7 +4,7 @@
 {% load markdown %}
 
 {% block extra_header_bar %}
-    <li class="list-group-item">
+    <li class="list-group-item d-print-none">
         <div class="dropdown">
             <a href="#" class="link-body-emphasis" data-bs-toggle="dropdown" aria-expanded="false">
                 Manage
@@ -72,55 +72,53 @@
 {% endif %}
 
 <!-- Existing Feature Cards -->
-<div class="row">
+<div class="row row-cols-auto">
 {% for group in feature_groups %}
-    <div class="card col-12">
+    <div class="card col avoidbreak {% if not group.taken %}d-print-none{% endif %}">
         <div class="card-body">
-        <h2 class="card-title">
-            {{ group.name }}
-        </h2>
-        <ul class="list-group">
-            {% if group.explain_list %}
-            <li class="list-group-item">
-                <ul>
-                {% for text in group.explain_list %}
-                    <li>{{ text }}</li>
-                {% endfor %}
-                </ul>
-            </li>
-            {% endif %}
-            {% for f in group.taken %}
-                <li class="list-group-item">
-                    <a href="{% url 'character-feature-view' character.id f.full_id %}">
-                        {% name_without_tags f group.type %}
-                        {% for level, badge in f.badges %}
-                        <span class="badge bg-{{level}}">{{badge}}</span>
-                        {% endfor %}
-                    </a>
-                    {% if f.subfeatures %}
-                    <ul>
-                        {% for sf in f.subfeatures %}
-                        <li>
-                            <a href="{% url 'character-feature-view' character.id sf.full_id%}">
-                                {% name_without_tags sf f.id %}
-                                {% for level, badge in sf.badges %}
-                                <span class="badge bg-{{level}}">{{badge}}</span>
-                                {% endfor %}
-                            </a>
-                        </li>
-                        {% endfor %}
-                    </ul>
-                    {% endif %}
-                </li>
-            {% endfor %}
-            {% if group.has_available %}
-            <li class="list-group-item">
-                <a class="link-success" href="#" role="button" data-bs-toggle="modal" data-bs-target="#newFeatureModal_{{group.type|slugify}}" aria-expanded="false" aria-controls="newFeatureModal_{{group.type|slugify}}">
-                    Add {{ group.name }}
+            <h2 class="card-title">
+                {{ group.name }}
+                {% if group.has_available %}
+                <a class="icon-link icon-link-hover link-success d-print-none" href="#" role="button"
+                    data-bs-toggle="modal" data-bs-target="#newFeatureModal_{{group.type|slugify}}"
+                    aria-expanded="false" aria-controls="newFeatureModal_{{group.type|slugify}}">
+                    <i class="bi bi-plus-circle"></i>
                 </a>
-            </li>
-            {% endif %}
+                {% endif %}
+            </h2>
+            {% if group.explain_list %}
+            <ul class="d-print-none list-group">
+            {% for text in group.explain_list %}
+                <li class="list-group-item">{{ text }}</li>
+            {% endfor %}
             </ul>
+            {% endif %}
+            <div class="row row-cols-auto">
+                {% for f in group.taken %}
+                    <div class="col card">
+                        <a href="{% url 'character-feature-view' character.id f.full_id %}">
+                            {% name_without_tags f group.type %}
+                            {% for level, badge in f.badges %}
+                            <span class="badge bg-{{level}} d-print-none">{{badge}}</span>
+                            {% endfor %}
+                        </a>
+                        {% if f.subfeatures %}
+                        <ul>
+                            {% for sf in f.subfeatures %}
+                            <li>
+                                <a href="{% url 'character-feature-view' character.id sf.full_id%}">
+                                    {% name_without_tags sf f.id %}
+                                    {% for level, badge in sf.badges %}
+                                    <span class="badge bg-{{level}} d-print-none">{{badge}}</span>
+                                    {% endfor %}
+                                </a>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+            </div>
         </div>
     </div>
 {% endfor %}

--- a/camp/character/templates/character/feature_form.html
+++ b/camp/character/templates/character/feature_form.html
@@ -30,14 +30,14 @@
     <p>Part of <a href="{% url 'character-feature-view' character.id feature.parent.id %}">{{ feature.parent.display_name }}</a></p>
     {% endif %}
 
-    {% if feature.supercedes %}
-    <p>Supercedes <a href="{% url 'character-feature-view' character.id feature.supercedes.id %}">
-        {{ feature.supercedes.display_name}}</a></p>
+    {% if feature.supersedes %}
+    <p>Supersedes <a href="{% url 'character-feature-view' character.id feature.supersedes.id %}">
+        {{ feature.supersedes.display_name}}</a></p>
     {% endif %}
 
-    {% if feature.is_superceded %}
-    <p>Superceded by <a href="{% url 'character-feature-view' character.id feature.superceded_by.id %}">
-        {{ feature.superceded_by.display_name }}</a></p>
+    {% if feature.is_superseded %}
+    <p>Superseded by <a href="{% url 'character-feature-view' character.id feature.superseded_by.id %}">
+        {{ feature.superseded_by.display_name }}</a></p>
     {% endif %}
 
     {% if purchase_form %}

--- a/camp/character/templates/character/feature_form.html
+++ b/camp/character/templates/character/feature_form.html
@@ -25,191 +25,211 @@
 
 {% include "character/card_snippet.html" with card=feature.power_card subcards=feature.sub_cards %}
 
-{% if feature.parent %}
-<p>Part of <a href="{% url 'character-feature-view' character.id feature.parent.id %}">{{ feature.parent.display_name }}</a></p>
-{% endif %}
+<div class="container">
+    {% if feature.parent %}
+    <p>Part of <a href="{% url 'character-feature-view' character.id feature.parent.id %}">{{ feature.parent.display_name }}</a></p>
+    {% endif %}
 
-{% if purchase_form %}
-{% if feature.unused_bonus > 0 %}
-<p>You have {{ feature.unused_bonus }} unused bonus rank(s). Your next purchase is free.</p>
-{% endif %}
+    {% if feature.supercedes %}
+    <p>Supercedes <a href="{% url 'character-feature-view' character.id feature.supercedes.id %}">
+        {{ feature.supercedes.display_name}}</a></p>
+    {% endif %}
 
-<form method="post" id="purchaseForm">
-    {% csrf_token %}
-        {{ purchase_form | crispy }}
-        {% if purchase_form.show_remove_button %}
-        <button type="submit" id="removeButton"
-                name="remove" value="1"
-                class="btn btn-danger">
-            Remove
-        </button>
-        {% else %}
-        <button type="submit" id="purchaseButton" name="purchase"
-                class="btn btn-{{purchase_form.button_level}}">
-            {{purchase_form.button_label}}
-        </button>
-        {% endif %}
+    {% if feature.is_superceded %}
+    <p>Superceded by <a href="{% url 'character-feature-view' character.id feature.superceded_by.id %}">
+        {{ feature.superceded_by.display_name }}</a></p>
+    {% endif %}
+
+    {% if purchase_form %}
+    {% if feature.unused_bonus > 0 %}
+    <p>You have {{ feature.unused_bonus }} unused bonus rank(s). Your next purchase is free.</p>
+    {% endif %}
+
+    <div class="d-print-none">
+    <form method="post" id="purchaseForm">
+        {% csrf_token %}
+            {{ purchase_form | crispy }}
+            {% if purchase_form.show_remove_button %}
+            <button type="submit" id="removeButton"
+                    name="remove" value="1"
+                    class="btn btn-danger">
+                Remove
+            </button>
+            {% else %}
+            <button type="submit" id="purchaseButton" name="purchase"
+                    class="btn btn-{{purchase_form.button_level}}">
+                {{purchase_form.button_label}}
+            </button>
+            {% endif %}
+        </div>
+    </form>
+    {% elif no_purchase_reason %}
+    <p>You can not currently purchase this because:</p>
+    <p>{{ no_purchase_reason | markdown }}</p>
+    {% endif %}
     </div>
-</form>
-{% elif no_purchase_reason %}
-<p>You can not currently purchase this because:</p>
-<p>{{ no_purchase_reason | markdown }}</p>
-{% endif %}
 
-{% if explain_ranks %}
-<h3>Details</h3>
-{% for explanation in explain_ranks %}
-<p>{{ explanation | markdown }}</p>
-{% endfor %}
-{% endif %}
-
-{% if feature.granted_features %}
-<h3>Granted Features</h3>
-<ul>
-{% for subfeat in feature.granted_features %}
-<li><a href="{% url 'character-feature-view' character.id subfeat.full_id %}">{% name_without_tags subfeat feature.id %}</a></li>
-{% endfor %}
-</ul>
-{% endif %}
-
-{% if feature.discounted_features %}
-<h3>Discounted Features</h3>
-<ul>
-{% for subfeat, amount in feature.discounted_features %}
-<li><a href="{% url 'character-feature-view' character.id subfeat.full_id %}">{{ subfeat.display_name }}: {{amount}}</a></li>
-{% endfor %}
-</ul>
-{% endif %}
-
-{% if choices %}
-<a name="choices"></a>
-{% for key, choice in choices.items %}
-    {% if choice.controller.limit > 1 %}
-    <h3>{{ choice.controller.name }} ({{choice.controller.choices_remaining}}/{{choice.controller.limit}})</h3>
-    {% else %}
-    <h3>{{ choice.controller.name }}</h3>
-    {% endif %}
-    {% if choice.controller.description %}
-    <p>{{ choice.controller.description | markdown }}</p>
-    {% endif %}
-    {% if choice.taken %}
-    <h4>Selected Choices</h4>
-    <form method="post">
-        {% csrf_token %}
-        <input type="hidden" name="unchoose" value="1">
-        <input type="hidden" name="choice" value="{{choice.id}}">
-        <ul>
-            {% for f, name in choice.taken.items %}
-            <li><a href="{% url 'character-feature-view' character.id f %}">{{ name }}</a>
-                {% if f in choice.removable %}
-                    <button type="submit" class="btn btn-danger btn-sm" name="selection" value="{{f}}">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
-                        <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6Z"/>
-                        <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1ZM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118ZM2.5 3h11V2h-11v1Z"/>
-                    </svg>
-                </button>
-                {% endif %}
-            </li>
-            {% endfor %}
-        </ul>
-    </form>
-    {% endif %}
-    {% if choice.available %}
-    <form method="post">
-        {% csrf_token %}
-        {{ choice | crispy }}
-        <button type="submit" name="choice" value="{{choice.id}}" class="btn btn-primary">Choose this option</button>
-    </form>
-    {% endif %}
-{% endfor %}
-{% endif %}
-
-{% if subfeatures %}
-<h3>Purchased Features</h3>
-<ul class="list-group">
-    {% for f in subfeatures %}
-    <li class="list-group-item">
-        <a href="{% url 'character-feature-view' character.id f.full_id %}">
-            {% name_without_tags f feature.id %}
-            {% for level, badge in f.badges %}
-            <span class="badge bg-{{level}}">{{badge}}</span>
-            {% endfor %}
-        </a>
-        {# Yeah I guess subfeatures could have subfeatures... #}
-        {% if f.subfeatures %}
-        <ul>
-            {% for sf in f.subfeatures %}
-            <li>
-                <a href="{% url 'character-feature-view' character.id sf.full_id%}">
-                    {% name_without_tags sf f.id %}
-                    {% for level, badge in sf.badges %}
-                    <span class="badge bg-{{level}}">{{badge}}</span>
-                    {% endfor %}
-                </a>
-            </li>
-            {% endfor %}
-        </ul>
-        {% endif %}
-    </li>
+    {% if explain_ranks %}
+    <div class="d-print-none">
+    <h3>Details</h3>
+    {% for explanation in explain_ranks %}
+    <p>{{ explanation | markdown }}</p>
     {% endfor %}
-</ul>
-{% endif %}
-
-{% for group in subfeatures_available %}
-{% if group.has_available %}
-    <h3>{{group.name}}</h3>
-    {% if group.explain %}
-    <p>{{ group.explain }}</p>
+    </div>
     {% endif %}
-    {% if group.available %}
-    <ul class="list-group list-group-flush">
-        {% for f in group.available %}
-            <li class="list-group-item">
-                <a href="{% url 'character-feature-view' character.id f.full_id%}">
-                    {% name_without_tags f feature.id group.type %}
-                    {% if f.purchase_cost_string %}
-                    ({{ f.purchase_cost_string }})
+
+    {% if feature.granted_features %}
+    <div class="d-print-none">
+    <h3>Granted Features</h3>
+    <ul>
+    {% for subfeat in feature.granted_features %}
+    <li><a href="{% url 'character-feature-view' character.id subfeat.full_id %}">{% name_without_tags subfeat feature.id %}</a></li>
+    {% endfor %}
+    </ul>
+    </div>
+    {% endif %}
+
+    {% if feature.discounted_features %}
+    <div class="d-print-none">
+    <h3>Discounted Features</h3>
+    <ul>
+    {% for subfeat, amount in feature.discounted_features %}
+    <li><a href="{% url 'character-feature-view' character.id subfeat.full_id %}">{{ subfeat.display_name }}: {{amount}}</a></li>
+    {% endfor %}
+    </ul>
+    </div>
+    {% endif %}
+
+    {% if choices %}
+    <a name="choices"></a>
+    {% for key, choice in choices.items %}
+        {% if choice.controller.limit > 1 %}
+        <h3>{{ choice.controller.name }} ({{choice.controller.choices_remaining}}/{{choice.controller.limit}})</h3>
+        {% else %}
+        <h3>{{ choice.controller.name }}</h3>
+        {% endif %}
+        {% if choice.controller.description %}
+        <p>{{ choice.controller.description | markdown }}</p>
+        {% endif %}
+        {% if choice.taken %}
+        <h4 class="d-print-none">Selected Choices</h4>
+        <form method="post">
+            {% csrf_token %}
+            <input type="hidden" name="unchoose" value="1">
+            <input type="hidden" name="choice" value="{{choice.id}}">
+            <ul>
+                {% for f, name in choice.taken.items %}
+                <li><a href="{% url 'character-feature-view' character.id f %}">{{ name }}</a>
+                    {% if f in choice.removable %}
+                        <button type="submit" class="btn btn-danger btn-sm d-print-none" name="selection" value="{{f}}">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash" viewBox="0 0 16 16">
+                            <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5Zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6Z"/>
+                            <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1ZM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118ZM2.5 3h11V2h-11v1Z"/>
+                        </svg>
+                    </button>
                     {% endif %}
-                </a>
-            </li>
+                </li>
+                {% endfor %}
+            </ul>
+        </form>
+        {% endif %}
+        {% if choice.available %}
+        <form method="post" class="d-print-none">
+            {% csrf_token %}
+            {{ choice | crispy }}
+            <button type="submit" name="choice" value="{{choice.id}}" class="btn btn-primary">Choose this option</button>
+        </form>
+        {% endif %}
+    {% endfor %}
+    {% endif %}
+
+    {% if subfeatures %}
+    <h3>Purchased Features</h3>
+    <ul class="list-group">
+        {% for f in subfeatures %}
+        <li class="list-group-item">
+            <a href="{% url 'character-feature-view' character.id f.full_id %}">
+                {% name_without_tags f feature.id %}
+                {% for level, badge in f.badges %}
+                <span class="badge bg-{{level}}">{{badge}}</span>
+                {% endfor %}
+            </a>
+            {# Yeah I guess subfeatures could have subfeatures... #}
+            {% if f.subfeatures %}
+            <ul>
+                {% for sf in f.subfeatures %}
+                <li>
+                    <a href="{% url 'character-feature-view' character.id sf.full_id%}">
+                        {% name_without_tags sf f.id %}
+                        {% for level, badge in sf.badges %}
+                        <span class="badge bg-{{level}}">{{badge}}</span>
+                        {% endfor %}
+                    </a>
+                </li>
+                {% endfor %}
+            </ul>
+            {% endif %}
+        </li>
         {% endfor %}
     </ul>
     {% endif %}
-    <div class="accordion" id="availableAccordian-{{group.type}}">
-    {% for category, available in group.available_categories.items %}
-        <div class="accordion-item">
-            <h2 class="accordion-header">
-                <button class="accordion-button {% if not forloop.first %}collapsed{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{group.type}}-{{category|slugify}}" aria-expanded="{{ forloop.first }}" aria-controls="collapse-{{category|slugify}}">
-                {{category}}
-                </button>
-            </h2>
-            <div id="collapse-{{group.type}}-{{category|slugify}}" class="accordion-collapse collapse {% if forloop.first %}show{% endif %}" data-bs-parent="#availableAccordian-{{group.type}}">
-                <div class="accordion-body">
-                    <ul class="list-group list-group-flush">
-                    {% if available.0.explain_category_group %}
-                    <li class="list-group-item">
-                        {{ available.0.explain_category_group }}
-                    </li>
-                    {% endif %}
-                    {% for f in available %}
-                    <li class="list-group-item">
-                        <a href="{% url 'character-feature-view' character.id f.full_id%}">
-                            {% name_without_tags f feature.id group.type %}
-                            {% if f.purchase_cost_string %}
-                            ({{ f.purchase_cost_string }})
-                            {% endif %}
-                        </a>
-                    </li>
-                    {% endfor %}
-                    </ul>
+
+    {% for group in subfeatures_available %}
+    {% if group.has_available %}
+        <h3>{{group.name}}</h3>
+        {% if group.explain %}
+        <p>{{ group.explain }}</p>
+        {% endif %}
+        {% if group.available %}
+        <ul class="list-group list-group-flush">
+            {% for f in group.available %}
+                <li class="list-group-item">
+                    <a href="{% url 'character-feature-view' character.id f.full_id%}">
+                        {% name_without_tags f feature.id group.type %}
+                        {% if f.purchase_cost_string %}
+                        ({{ f.purchase_cost_string }})
+                        {% endif %}
+                    </a>
+                </li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+        <div class="accordion" id="availableAccordian-{{group.type}}">
+        {% for category, available in group.available_categories.items %}
+            <div class="accordion-item">
+                <h2 class="accordion-header">
+                    <button class="accordion-button {% if not forloop.first %}collapsed{% endif %}" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{{group.type}}-{{category|slugify}}" aria-expanded="{{ forloop.first }}" aria-controls="collapse-{{category|slugify}}">
+                    {{category}}
+                    </button>
+                </h2>
+                <div id="collapse-{{group.type}}-{{category|slugify}}" class="accordion-collapse collapse {% if forloop.first %}show{% endif %}" data-bs-parent="#availableAccordian-{{group.type}}">
+                    <div class="accordion-body">
+                        <ul class="list-group list-group-flush">
+                        {% if available.0.explain_category_group %}
+                        <li class="list-group-item">
+                            {{ available.0.explain_category_group }}
+                        </li>
+                        {% endif %}
+                        {% for f in available %}
+                        <li class="list-group-item">
+                            <a href="{% url 'character-feature-view' character.id f.full_id%}">
+                                {% name_without_tags f feature.id group.type %}
+                                {% if f.purchase_cost_string %}
+                                ({{ f.purchase_cost_string }})
+                                {% endif %}
+                            </a>
+                        </li>
+                        {% endfor %}
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
+        {% endfor %}
+        {% endif %}
     {% endfor %}
-    {% endif %}
-{% endfor %}
 
-<a role="button" class="btn btn-secondary" href="{% url 'character-detail' character.id %}">Back to {{character}}</a>
+    <a role="button" class="btn btn-secondary d-print-none" href="{% url 'character-detail' character.id %}">Back to {{character}}</a>
+</div>
 
 {% endblock %}
 

--- a/camp/engine/rules/base_engine.py
+++ b/camp/engine/rules/base_engine.py
@@ -115,7 +115,7 @@ class CharacterController(ABC):
                     continue
                 if available and not fc.can_increase():
                     continue
-                if fc.is_superceded:
+                if fc.is_superceded and not fc.has_available_choices:
                     continue
                 if fc.should_show_in_list or not filter_subfeatures:
                     yield fc
@@ -702,6 +702,12 @@ class BaseFeatureController(PropertyController):
     @property
     def meets_requirements(self) -> Decision:
         return self.character.meets_requirements(self.definition.requires, self.full_id)
+
+    @abstractproperty
+    def has_available_choices(self) -> bool: ...
+
+    @abstractproperty
+    def choices(self) -> dict[str, ChoiceController] | None: ...
 
     @property
     def next_value(self) -> int | None:

--- a/camp/engine/rules/base_engine.py
+++ b/camp/engine/rules/base_engine.py
@@ -115,7 +115,7 @@ class CharacterController(ABC):
                     continue
                 if available and not fc.can_increase():
                     continue
-                if fc.is_superceded and not fc.has_available_choices:
+                if fc.is_superseded and not fc.has_available_choices:
                     continue
                 if fc.should_show_in_list or not filter_subfeatures:
                     yield fc
@@ -647,21 +647,21 @@ class BaseFeatureController(PropertyController):
         return parent
 
     @property
-    def supercedes(self) -> BaseFeatureController | None:
-        if self.definition.supercedes is None:
+    def supersedes(self) -> BaseFeatureController | None:
+        if self.definition.supersedes is None:
             return None
-        return self.character.feature_controller(self.definition.supercedes)
+        return self.character.feature_controller(self.definition.supersedes)
 
     @property
-    def superceded_by(self) -> BaseFeatureController | None:
-        if self.definition.superceded_by is None:
+    def superseded_by(self) -> BaseFeatureController | None:
+        if self.definition.superseded_by is None:
             return None
-        return self.character.feature_controller(self.definition.superceded_by)
+        return self.character.feature_controller(self.definition.superseded_by)
 
     @property
-    def is_superceded(self) -> bool:
-        if superceded_by := self.superceded_by:
-            return superceded_by.value > 0
+    def is_superseded(self) -> bool:
+        if superseded_by := self.superseded_by:
+            return superseded_by.value > 0
         return False
 
     @cached_property

--- a/camp/engine/rules/base_engine.py
+++ b/camp/engine/rules/base_engine.py
@@ -115,6 +115,8 @@ class CharacterController(ABC):
                     continue
                 if available and not fc.can_increase():
                     continue
+                if fc.is_superceded:
+                    continue
                 if fc.should_show_in_list or not filter_subfeatures:
                     yield fc
         else:
@@ -643,6 +645,24 @@ class BaseFeatureController(PropertyController):
                 if extra_controller.value > 0:
                     return extra_controller
         return parent
+
+    @property
+    def supercedes(self) -> BaseFeatureController | None:
+        if self.definition.supercedes is None:
+            return None
+        return self.character.feature_controller(self.definition.supercedes)
+
+    @property
+    def superceded_by(self) -> BaseFeatureController | None:
+        if self.definition.superceded_by is None:
+            return None
+        return self.character.feature_controller(self.definition.superceded_by)
+
+    @property
+    def is_superceded(self) -> bool:
+        if superceded_by := self.superceded_by:
+            return superceded_by.value > 0
+        return False
 
     @cached_property
     def tags(self) -> set[str]:

--- a/camp/engine/rules/base_models.py
+++ b/camp/engine/rules/base_models.py
@@ -408,7 +408,7 @@ class BaseFeatureDef(BaseModel):
         option_def: If a feature has "options", the definition should be provided here. See OptionDef
             for more details, but tl;dr this allows a single definition that can have multiple independent
             purchases, such as a "Lore" skill that can be purchased as "Lore [Undead]" or "Lore [Arcane]".
-        supercedes: Suppresses the given feature from display on the main character sheet if this feature
+        supersedes: Suppresses the given feature from display on the main character sheet if this feature
             has ranks. For example, if you don't want to show Forage I if you've got Forage II.
     """
 
@@ -416,7 +416,7 @@ class BaseFeatureDef(BaseModel):
     name: str
     type: str
     parent: str | None = None
-    supercedes: str | None = None
+    supersedes: str | None = None
     category: str | None = None
     category_priority: float = 100.0
     requires: Requirements = None
@@ -432,7 +432,7 @@ class BaseFeatureDef(BaseModel):
     _child_ids: set[str] = pydantic.PrivateAttr(default_factory=set)
     _uncles: set[str] = pydantic.PrivateAttr(default_factory=set)
     _parent_def: BaseFeatureDef | None = pydantic.PrivateAttr(default=None)
-    _superceded_by: str | None = pydantic.PrivateAttr(default=None)
+    _superseded_by: str | None = pydantic.PrivateAttr(default=None)
 
     @classmethod
     def default_name(cls) -> str:
@@ -471,8 +471,8 @@ class BaseFeatureDef(BaseModel):
         return self._uncles
 
     @property
-    def superceded_by(self) -> str | None:
-        return self._superceded_by
+    def superseded_by(self) -> str | None:
+        return self._superseded_by
 
     def post_validate(self, ruleset: BaseRuleset) -> None:
         self.requires = parse_req(self.requires)
@@ -483,10 +483,10 @@ class BaseFeatureDef(BaseModel):
             parent = ruleset.features[self.parent]
             parent._child_ids.add(self.id)
             self._parent_def = parent
-        if self.supercedes:
-            ruleset.validate_identifiers([self.supercedes])
-            previous = ruleset.features[self.supercedes]
-            previous._superceded_by = self.id
+        if self.supersedes:
+            ruleset.validate_identifiers([self.supersedes])
+            previous = ruleset.features[self.supersedes]
+            previous._superseded_by = self.id
         if self.inherit_children:
             ruleset.validate_identifiers(self.inherit_children)
             for uncle in self.inherit_children:

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-2.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-2.yaml
@@ -1,6 +1,6 @@
 name: Draconic Heritage II
 cost: 3
-supercedes: draconic-heritage-1
+supersedes: draconic-heritage-1
 requires:
   - level:5
   - draconic-heritage-1

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-2.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-2.yaml
@@ -1,5 +1,6 @@
 name: Draconic Heritage II
 cost: 3
+supercedes: draconic-heritage-1
 requires:
   - level:5
   - draconic-heritage-1

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-3.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-3.yaml
@@ -1,6 +1,6 @@
 name: Draconic Heritage III
 cost: 4
-supercedes: draconic-heritage-2
+supersedes: draconic-heritage-2
 requires:
   - level:10
   - draconic-heritage-2

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-3.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-3.yaml
@@ -1,5 +1,6 @@
 name: Draconic Heritage III
 cost: 4
+supercedes: draconic-heritage-2
 requires:
   - level:10
   - draconic-heritage-2

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-4.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-4.yaml
@@ -1,5 +1,6 @@
 name: Draconic Heritage IV
 cost: 5
+supercedes: draconic-heritage-3
 requires:
   - level:15
   - draconic-heritage-3

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-4.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-4.yaml
@@ -1,6 +1,6 @@
 name: Draconic Heritage IV
 cost: 5
-supercedes: draconic-heritage-3
+supersedes: draconic-heritage-3
 requires:
   - level:15
   - draconic-heritage-3

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-5.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-5.yaml
@@ -1,6 +1,6 @@
 name: Draconic Heritage V
 cost: 6
-supercedes: draconic-heritage-4
+supersedes: draconic-heritage-4
 requires:
   - level:20
   - draconic-heritage-4

--- a/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-5.yaml
+++ b/camp/tempest/v1/perks/social/draconic-heritage/draconic-heritage-5.yaml
@@ -1,5 +1,6 @@
 name: Draconic Heritage V
 cost: 6
+supercedes: draconic-heritage-4
 requires:
   - level:20
   - draconic-heritage-4

--- a/camp/tempest/v1/skills/crafting/alchemy/greater-alchemy.yaml
+++ b/camp/tempest/v1/skills/crafting/alchemy/greater-alchemy.yaml
@@ -1,6 +1,6 @@
 name: Greater Alchemy
 cost: 5
-supercedes: journeyman-alchemy
+supersedes: journeyman-alchemy
 requires:
   - journeyman-alchemy
   - level:10

--- a/camp/tempest/v1/skills/crafting/alchemy/greater-alchemy.yaml
+++ b/camp/tempest/v1/skills/crafting/alchemy/greater-alchemy.yaml
@@ -1,5 +1,6 @@
 name: Greater Alchemy
 cost: 5
+supercedes: journeyman-alchemy
 requires:
   - journeyman-alchemy
   - level:10

--- a/camp/tempest/v1/skills/crafting/alchemy/journeyman-alchemy.yaml
+++ b/camp/tempest/v1/skills/crafting/alchemy/journeyman-alchemy.yaml
@@ -1,6 +1,6 @@
 name: Journeyman Alchemy
 cost: 4
-supercedes: apprentice-alchemy
+supersedes: apprentice-alchemy
 requires:
   - apprentice-alchemy
   - level:4

--- a/camp/tempest/v1/skills/crafting/alchemy/journeyman-alchemy.yaml
+++ b/camp/tempest/v1/skills/crafting/alchemy/journeyman-alchemy.yaml
@@ -1,5 +1,6 @@
 name: Journeyman Alchemy
 cost: 4
+supercedes: apprentice-alchemy
 requires:
   - apprentice-alchemy
   - level:4

--- a/camp/tempest/v1/skills/crafting/alchemy/master-alchemy.yaml
+++ b/camp/tempest/v1/skills/crafting/alchemy/master-alchemy.yaml
@@ -1,5 +1,6 @@
 name: Master Alchemy
 cost: 6
+supercedes: greater-alchemy
 requires:
   - greater-alchemy
   - level:16

--- a/camp/tempest/v1/skills/crafting/alchemy/master-alchemy.yaml
+++ b/camp/tempest/v1/skills/crafting/alchemy/master-alchemy.yaml
@@ -1,6 +1,6 @@
 name: Master Alchemy
 cost: 6
-supercedes: greater-alchemy
+supersedes: greater-alchemy
 requires:
   - greater-alchemy
   - level:16

--- a/camp/tempest/v1/skills/crafting/arcane-ritual/greater-arcane-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/arcane-ritual/greater-arcane-ritual.yaml
@@ -1,5 +1,6 @@
 name: Greater Arcane Ritual Magic
 cost: 5
+supercedes: journeyman-arcane-ritual
 requires:
   - journeyman-arcane-ritual
   - level:10

--- a/camp/tempest/v1/skills/crafting/arcane-ritual/greater-arcane-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/arcane-ritual/greater-arcane-ritual.yaml
@@ -1,6 +1,6 @@
 name: Greater Arcane Ritual Magic
 cost: 5
-supercedes: journeyman-arcane-ritual
+supersedes: journeyman-arcane-ritual
 requires:
   - journeyman-arcane-ritual
   - level:10

--- a/camp/tempest/v1/skills/crafting/arcane-ritual/journeyman-arcane-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/arcane-ritual/journeyman-arcane-ritual.yaml
@@ -1,6 +1,6 @@
 name: Journeyman Arcane Ritual Magic
 cost: 4
-supercedes: apprentice-arcane-ritual
+supersedes: apprentice-arcane-ritual
 requires:
   - apprentice-arcane-ritual
   - level:4

--- a/camp/tempest/v1/skills/crafting/arcane-ritual/journeyman-arcane-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/arcane-ritual/journeyman-arcane-ritual.yaml
@@ -1,5 +1,6 @@
 name: Journeyman Arcane Ritual Magic
 cost: 4
+supercedes: apprentice-arcane-ritual
 requires:
   - apprentice-arcane-ritual
   - level:4

--- a/camp/tempest/v1/skills/crafting/arcane-ritual/master-arcane-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/arcane-ritual/master-arcane-ritual.yaml
@@ -1,6 +1,6 @@
 name: Master Arcane Ritual Magic
 cost: 6
-supercedes: greater-arcane-ritual
+supersedes: greater-arcane-ritual
 requires:
   - greater-arcane-ritual
   - level:16

--- a/camp/tempest/v1/skills/crafting/arcane-ritual/master-arcane-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/arcane-ritual/master-arcane-ritual.yaml
@@ -1,5 +1,6 @@
 name: Master Arcane Ritual Magic
 cost: 6
+supercedes: greater-arcane-ritual
 requires:
   - greater-arcane-ritual
   - level:16

--- a/camp/tempest/v1/skills/crafting/divine-ritual/greater-divine-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/divine-ritual/greater-divine-ritual.yaml
@@ -1,5 +1,6 @@
 name: Greater Divine Ritual Magic
 cost: 5
+supercedes: journeyman-divine-ritual
 requires:
   - journeyman-divine-ritual
   - level:10

--- a/camp/tempest/v1/skills/crafting/divine-ritual/greater-divine-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/divine-ritual/greater-divine-ritual.yaml
@@ -1,6 +1,6 @@
 name: Greater Divine Ritual Magic
 cost: 5
-supercedes: journeyman-divine-ritual
+supersedes: journeyman-divine-ritual
 requires:
   - journeyman-divine-ritual
   - level:10

--- a/camp/tempest/v1/skills/crafting/divine-ritual/journeyman-divine-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/divine-ritual/journeyman-divine-ritual.yaml
@@ -1,6 +1,6 @@
 name: Journeyman Divine Ritual Magic
 cost: 4
-supercedes: apprentice-divine-ritual
+supersedes: apprentice-divine-ritual
 requires:
   - apprentice-divine-ritual
   - level:4

--- a/camp/tempest/v1/skills/crafting/divine-ritual/journeyman-divine-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/divine-ritual/journeyman-divine-ritual.yaml
@@ -1,5 +1,6 @@
 name: Journeyman Divine Ritual Magic
 cost: 4
+supercedes: apprentice-divine-ritual
 requires:
   - apprentice-divine-ritual
   - level:4

--- a/camp/tempest/v1/skills/crafting/divine-ritual/master-divine-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/divine-ritual/master-divine-ritual.yaml
@@ -1,5 +1,6 @@
 name: Master Divine Ritual Magic
 cost: 6
+supercedes: greater-divine-ritual
 requires:
   - greater-divine-ritual
   - level:16

--- a/camp/tempest/v1/skills/crafting/divine-ritual/master-divine-ritual.yaml
+++ b/camp/tempest/v1/skills/crafting/divine-ritual/master-divine-ritual.yaml
@@ -1,6 +1,6 @@
 name: Master Divine Ritual Magic
 cost: 6
-supercedes: greater-divine-ritual
+supersedes: greater-divine-ritual
 requires:
   - greater-divine-ritual
   - level:16

--- a/camp/tempest/v1/skills/crafting/enchanting/greater-enchanting.yaml
+++ b/camp/tempest/v1/skills/crafting/enchanting/greater-enchanting.yaml
@@ -1,5 +1,6 @@
 name: Greater Enchanting
 cost: 5
+supercedes: journeyman-enchanting
 requires:
   - journeyman-enchanting
   - level:10

--- a/camp/tempest/v1/skills/crafting/enchanting/greater-enchanting.yaml
+++ b/camp/tempest/v1/skills/crafting/enchanting/greater-enchanting.yaml
@@ -1,6 +1,6 @@
 name: Greater Enchanting
 cost: 5
-supercedes: journeyman-enchanting
+supersedes: journeyman-enchanting
 requires:
   - journeyman-enchanting
   - level:10

--- a/camp/tempest/v1/skills/crafting/enchanting/journeyman-enchanting.yaml
+++ b/camp/tempest/v1/skills/crafting/enchanting/journeyman-enchanting.yaml
@@ -1,6 +1,6 @@
 name: Journeyman Enchanting
 cost: 4
-supercedes: apprentice-enchanting
+supersedes: apprentice-enchanting
 requires:
   - apprentice-enchanting
   - level:4

--- a/camp/tempest/v1/skills/crafting/enchanting/journeyman-enchanting.yaml
+++ b/camp/tempest/v1/skills/crafting/enchanting/journeyman-enchanting.yaml
@@ -1,5 +1,6 @@
 name: Journeyman Enchanting
 cost: 4
+supercedes: apprentice-enchanting
 requires:
   - apprentice-enchanting
   - level:4

--- a/camp/tempest/v1/skills/crafting/enchanting/master-enchanting.yaml
+++ b/camp/tempest/v1/skills/crafting/enchanting/master-enchanting.yaml
@@ -1,5 +1,6 @@
 name: Master Enchanting
 cost: 6
+supercedes: greater-enchanting
 requires:
   - greater-enchanting
   - level:16

--- a/camp/tempest/v1/skills/crafting/enchanting/master-enchanting.yaml
+++ b/camp/tempest/v1/skills/crafting/enchanting/master-enchanting.yaml
@@ -1,6 +1,6 @@
 name: Master Enchanting
 cost: 6
-supercedes: greater-enchanting
+supersedes: greater-enchanting
 requires:
   - greater-enchanting
   - level:16

--- a/camp/tempest/v1/skills/crafting/tinkering/greater-tinkering.yaml
+++ b/camp/tempest/v1/skills/crafting/tinkering/greater-tinkering.yaml
@@ -1,6 +1,6 @@
 name: Greater Tinkering
 cost: 5
-supercedes: journeyman-tinkering
+supersedes: journeyman-tinkering
 requires:
   - journeyman-tinkering
   - level:10

--- a/camp/tempest/v1/skills/crafting/tinkering/greater-tinkering.yaml
+++ b/camp/tempest/v1/skills/crafting/tinkering/greater-tinkering.yaml
@@ -1,5 +1,6 @@
 name: Greater Tinkering
 cost: 5
+supercedes: journeyman-tinkering
 requires:
   - journeyman-tinkering
   - level:10

--- a/camp/tempest/v1/skills/crafting/tinkering/journeyman-tinkering.yaml
+++ b/camp/tempest/v1/skills/crafting/tinkering/journeyman-tinkering.yaml
@@ -1,5 +1,6 @@
 name: Journeyman Tinkering
 cost: 4
+supercedes: apprentice-tinkering
 requires:
   - apprentice-tinkering
   - level:4

--- a/camp/tempest/v1/skills/crafting/tinkering/journeyman-tinkering.yaml
+++ b/camp/tempest/v1/skills/crafting/tinkering/journeyman-tinkering.yaml
@@ -1,6 +1,6 @@
 name: Journeyman Tinkering
 cost: 4
-supercedes: apprentice-tinkering
+supersedes: apprentice-tinkering
 requires:
   - apprentice-tinkering
   - level:4

--- a/camp/tempest/v1/skills/crafting/tinkering/master-tinkering.yaml
+++ b/camp/tempest/v1/skills/crafting/tinkering/master-tinkering.yaml
@@ -1,6 +1,6 @@
 name: Master Tinkering
 cost: 6
-supercedes: greater-tinkering
+supersedes: greater-tinkering
 requires:
   - greater-tinkering
   - level:16

--- a/camp/tempest/v1/skills/crafting/tinkering/master-tinkering.yaml
+++ b/camp/tempest/v1/skills/crafting/tinkering/master-tinkering.yaml
@@ -1,5 +1,6 @@
 name: Master Tinkering
 cost: 6
+supercedes: greater-tinkering
 requires:
   - greater-tinkering
   - level:16

--- a/camp/tempest/v1/skills/gathering/forage-2.yaml
+++ b/camp/tempest/v1/skills/gathering/forage-2.yaml
@@ -1,5 +1,6 @@
 name: Forage II
 cost: 3
+supercedes: forage-1
 requires: forage-1
 description: |
   The character can Forage up to 30 Bloom and 14 Night Prizes per Event. In addition, certain resources are gated behind each rank of this skill, allowing those with greater proficiency to gather more difficult to obtain resources.

--- a/camp/tempest/v1/skills/gathering/forage-2.yaml
+++ b/camp/tempest/v1/skills/gathering/forage-2.yaml
@@ -1,6 +1,6 @@
 name: Forage II
 cost: 3
-supercedes: forage-1
+supersedes: forage-1
 requires: forage-1
 description: |
   The character can Forage up to 30 Bloom and 14 Night Prizes per Event. In addition, certain resources are gated behind each rank of this skill, allowing those with greater proficiency to gather more difficult to obtain resources.

--- a/camp/tempest/v1/skills/gathering/forage-3.yaml
+++ b/camp/tempest/v1/skills/gathering/forage-3.yaml
@@ -1,9 +1,10 @@
 name: Forage III
 cost: 3
+supercedes: forage-2
 requires:
   - forage-2
   - any:
-    - level:10
-    - hunter-gatherer
+      - level:10
+      - hunter-gatherer
 description: |
   The character can Forage up to 45 Bloom and 21 Night Prizes per Event. In addition, certain resources are gated behind each rank of this skill, allowing those with greater proficiency to gather more difficult to obtain resources. Notably, Eternal Blossom for example may only be Foraged by rank 3 Foraging.

--- a/camp/tempest/v1/skills/gathering/forage-3.yaml
+++ b/camp/tempest/v1/skills/gathering/forage-3.yaml
@@ -1,6 +1,6 @@
 name: Forage III
 cost: 3
-supercedes: forage-2
+supersedes: forage-2
 requires:
   - forage-2
   - any:

--- a/camp/tempest/v1/skills/gathering/prospect-2.yaml
+++ b/camp/tempest/v1/skills/gathering/prospect-2.yaml
@@ -1,6 +1,6 @@
 name: Prospect II
 cost: 3
-supercedes: prospect-1
+supersedes: prospect-1
 requires: prospect-1
 description: |
   Higher ranks of prospecting are more likely to yield Rare Minerals.

--- a/camp/tempest/v1/skills/gathering/prospect-2.yaml
+++ b/camp/tempest/v1/skills/gathering/prospect-2.yaml
@@ -1,5 +1,6 @@
 name: Prospect II
 cost: 3
+supercedes: prospect-1
 requires: prospect-1
 description: |
   Higher ranks of prospecting are more likely to yield Rare Minerals.

--- a/camp/tempest/v1/skills/gathering/prospect-3.yaml
+++ b/camp/tempest/v1/skills/gathering/prospect-3.yaml
@@ -1,9 +1,10 @@
 name: Prospect III
 cost: 3
+supercedes: prospect-2
 requires:
   - prospect-2
   - any:
-    - level:10
-    - good-timing
+      - level:10
+      - good-timing
 description: |
   Higher ranks of prospecting are more likely to yield Rare Minerals. Additionally, Mithril Ore will only be obtainable by characters with Rank 3 Prospecting.

--- a/camp/tempest/v1/skills/gathering/prospect-3.yaml
+++ b/camp/tempest/v1/skills/gathering/prospect-3.yaml
@@ -1,6 +1,6 @@
 name: Prospect III
 cost: 3
-supercedes: prospect-2
+supersedes: prospect-2
 requires:
   - prospect-2
   - any:

--- a/camp/tempest/v1/skills/gathering/scavenging-2.yaml
+++ b/camp/tempest/v1/skills/gathering/scavenging-2.yaml
@@ -1,6 +1,6 @@
 name: Scavenging II
 cost: 3
-supercedes: scavenging-1
+supersedes: scavenging-1
 requires: scavenging-1
 description: |
   The NPC will turn over more valuable types of tokens than Scavenging I if a proper skinning knife is used.  Additionally, the time it takes to Scavenge them is reduced to a Quick 50 plus the time it takes you to receive the token from the portrayer. Yields from the Scavenging decks will also be improved.

--- a/camp/tempest/v1/skills/gathering/scavenging-2.yaml
+++ b/camp/tempest/v1/skills/gathering/scavenging-2.yaml
@@ -1,5 +1,6 @@
 name: Scavenging II
 cost: 3
+supercedes: scavenging-1
 requires: scavenging-1
 description: |
   The NPC will turn over more valuable types of tokens than Scavenging I if a proper skinning knife is used.  Additionally, the time it takes to Scavenge them is reduced to a Quick 50 plus the time it takes you to receive the token from the portrayer. Yields from the Scavenging decks will also be improved.

--- a/camp/tempest/v1/skills/gathering/scavenging-3.yaml
+++ b/camp/tempest/v1/skills/gathering/scavenging-3.yaml
@@ -1,6 +1,6 @@
 name: Scavenging III
 cost: 3
-supercedes: scavenging-2
+supersedes: scavenging-2
 requires:
   - scavenging-2
   - any:

--- a/camp/tempest/v1/skills/gathering/scavenging-3.yaml
+++ b/camp/tempest/v1/skills/gathering/scavenging-3.yaml
@@ -1,9 +1,10 @@
 name: Scavenging III
 cost: 3
+supercedes: scavenging-2
 requires:
   - scavenging-2
   - any:
-    - level:10
-    - tanner
+      - level:10
+      - tanner
 description: |
   The NPC will turn over more valuable types of tokens than Scavenging II if a proper skinning knife is used.  Additionally, the time it takes to Scavenge them is reduced to a Quick 30 plus the time it takes you to receive the token from the portrayer. Yields from the Scavenging decks will also be improved.

--- a/camp/tempest/v1/skills/magic/bookcasting/adept-bookcaster.yaml
+++ b/camp/tempest/v1/skills/magic/bookcasting/adept-bookcaster.yaml
@@ -1,9 +1,10 @@
 name: Adept Bookcaster
 cost: 2
+supercedes: novice-bookcaster
 requires:
   - novice-bookcaster
   - any:
-    - arcane.spell_slots@2
-    - divine.spell_slots@2
+      - arcane.spell_slots@2
+      - divine.spell_slots@2
 description: |
   The character can cast Adept level spells directly from their spellbook. Although the spell will still exhaust an Adept Spell-Slot, it need not be Prepared (although it must be a spell the caster could Prepare). To bookcast a spell, the character must be out of combat, then they must either read the full incant five times from their spell-book, or must study their spellbook for a full minute before reading the incantation directly from the book. All other requirements and components will remain the same.

--- a/camp/tempest/v1/skills/magic/bookcasting/adept-bookcaster.yaml
+++ b/camp/tempest/v1/skills/magic/bookcasting/adept-bookcaster.yaml
@@ -1,6 +1,6 @@
 name: Adept Bookcaster
 cost: 2
-supercedes: novice-bookcaster
+supersedes: novice-bookcaster
 requires:
   - novice-bookcaster
   - any:

--- a/camp/tempest/v1/skills/magic/bookcasting/greater-bookcaster.yaml
+++ b/camp/tempest/v1/skills/magic/bookcasting/greater-bookcaster.yaml
@@ -1,10 +1,11 @@
 name: Greater Bookcaster
 cost: 3
+supercedes: adept-bookcaster
 requires:
   - adept-bookcaster
   - any:
-    - arcane.spell_slots@3
-    - divine.spell_slots@3
+      - arcane.spell_slots@3
+      - divine.spell_slots@3
 description: |
   The character can cast Greater spells directly from her spellbook.
   Although the spell will still exhaust a Greater Spell-Slot, it need not

--- a/camp/tempest/v1/skills/magic/bookcasting/greater-bookcaster.yaml
+++ b/camp/tempest/v1/skills/magic/bookcasting/greater-bookcaster.yaml
@@ -1,6 +1,6 @@
 name: Greater Bookcaster
 cost: 3
-supercedes: adept-bookcaster
+supersedes: adept-bookcaster
 requires:
   - adept-bookcaster
   - any:

--- a/camp/tempest/v1/skills/martial/armor-profs/heavy-armor.yaml
+++ b/camp/tempest/v1/skills/martial/armor-profs/heavy-armor.yaml
@@ -1,5 +1,6 @@
 name: Heavy Armor
 cost: 3
+supercedes: medium-armor
 requires: medium-armor
 description: |
   The character can benefit from up to eight Armor Points of repped armor. Their total armor can still be altered by character Skills and Powers, which may increase their armor above this repped armor maximum.

--- a/camp/tempest/v1/skills/martial/armor-profs/heavy-armor.yaml
+++ b/camp/tempest/v1/skills/martial/armor-profs/heavy-armor.yaml
@@ -1,6 +1,6 @@
 name: Heavy Armor
 cost: 3
-supercedes: medium-armor
+supersedes: medium-armor
 requires: medium-armor
 description: |
   The character can benefit from up to eight Armor Points of repped armor. Their total armor can still be altered by character Skills and Powers, which may increase their armor above this repped armor maximum.

--- a/camp/tempest/v1/skills/martial/armor-profs/ironclad-armor.yaml
+++ b/camp/tempest/v1/skills/martial/armor-profs/ironclad-armor.yaml
@@ -1,5 +1,6 @@
 name: Ironclad Armor
 cost: 2
+supercedes: heavy-armor
 requires: heavy-armor
 description: |
   The character can benefit from up to eleven Armor Points of repped armor. Their total armor can still be altered by character Skills and Powers, which may increase their armor above this repped armor maximum.

--- a/camp/tempest/v1/skills/martial/armor-profs/ironclad-armor.yaml
+++ b/camp/tempest/v1/skills/martial/armor-profs/ironclad-armor.yaml
@@ -1,6 +1,6 @@
 name: Ironclad Armor
 cost: 2
-supercedes: heavy-armor
+supersedes: heavy-armor
 requires: heavy-armor
 description: |
   The character can benefit from up to eleven Armor Points of repped armor. Their total armor can still be altered by character Skills and Powers, which may increase their armor above this repped armor maximum.

--- a/camp/tempest/v1/skills/martial/armor-profs/light-armor.yaml
+++ b/camp/tempest/v1/skills/martial/armor-profs/light-armor.yaml
@@ -1,6 +1,6 @@
 name: Light Armor
 cost: 3
-supercedes: basic-armor
+supersedes: basic-armor
 requires: basic-armor
 description: |
   The character can benefit from up to four Armor Points of repped armor. Their total armor can still be altered by character Skills and Powers, which may increase their armor above this repped armor maximum.

--- a/camp/tempest/v1/skills/martial/armor-profs/light-armor.yaml
+++ b/camp/tempest/v1/skills/martial/armor-profs/light-armor.yaml
@@ -1,5 +1,6 @@
 name: Light Armor
 cost: 3
+supercedes: basic-armor
 requires: basic-armor
 description: |
   The character can benefit from up to four Armor Points of repped armor. Their total armor can still be altered by character Skills and Powers, which may increase their armor above this repped armor maximum.

--- a/camp/tempest/v1/skills/martial/armor-profs/medium-armor.yaml
+++ b/camp/tempest/v1/skills/martial/armor-profs/medium-armor.yaml
@@ -1,5 +1,6 @@
 name: Medium Armor
 cost: 4
+supercedes: light-armor
 requires: light-armor
 description: |
   The character can benefit from up to six Armor Points of repped armor. Their total armor can still be altered by character Skills and Powers, which may increase their armor above this repped armor maximum.

--- a/camp/tempest/v1/skills/martial/armor-profs/medium-armor.yaml
+++ b/camp/tempest/v1/skills/martial/armor-profs/medium-armor.yaml
@@ -1,6 +1,6 @@
 name: Medium Armor
 cost: 4
-supercedes: light-armor
+supersedes: light-armor
 requires: light-armor
 description: |
   The character can benefit from up to six Armor Points of repped armor. Their total armor can still be altered by character Skills and Powers, which may increase their armor above this repped armor maximum.

--- a/camp/tempest/v1/skills/martial/shield-profs/advanced-shields.yaml
+++ b/camp/tempest/v1/skills/martial/shield-profs/advanced-shields.yaml
@@ -1,5 +1,6 @@
 name: Advanced Shields
 cost: 2
+supercedes: basic-shields
 requires: basic-shields
 description: |
   The character has proficiency with Medium (94” perimeter max) and Large shields (106” perimeter max).

--- a/camp/tempest/v1/skills/martial/shield-profs/advanced-shields.yaml
+++ b/camp/tempest/v1/skills/martial/shield-profs/advanced-shields.yaml
@@ -1,6 +1,6 @@
 name: Advanced Shields
 cost: 2
-supercedes: basic-shields
+supersedes: basic-shields
 requires: basic-shields
 description: |
   The character has proficiency with Medium (94” perimeter max) and Large shields (106” perimeter max).

--- a/camp/tempest/v1/skills/martial/shield-profs/great-shields.yaml
+++ b/camp/tempest/v1/skills/martial/shield-profs/great-shields.yaml
@@ -1,5 +1,6 @@
 name: Great Shields
 cost: 2
+supercedes: advanced-shields
 requires: advanced-shields
 description: |
   The character has proficiency with Great shields (125” perimeter max).

--- a/camp/tempest/v1/skills/martial/shield-profs/great-shields.yaml
+++ b/camp/tempest/v1/skills/martial/shield-profs/great-shields.yaml
@@ -1,6 +1,6 @@
 name: Great Shields
 cost: 2
-supercedes: advanced-shields
+supersedes: advanced-shields
 requires: advanced-shields
 description: |
   The character has proficiency with Great shields (125” perimeter max).

--- a/camp/tempest/v1/skills/medical/advanced-medicine.yaml
+++ b/camp/tempest/v1/skills/medical/advanced-medicine.yaml
@@ -1,6 +1,6 @@
 name: Advanced Medicine
 cost: 4
-supercedes: basic-medicine
+supersedes: basic-medicine
 requires: basic-medicine
 description: |
   The character has a number of techniques at their disposal to help those around them. The character can perform any of the following actions by spending a Slow 60 out of combat tending to another (these cannot be performed on the character themself). These can be done as part of a Short Rest.

--- a/camp/tempest/v1/skills/medical/advanced-medicine.yaml
+++ b/camp/tempest/v1/skills/medical/advanced-medicine.yaml
@@ -1,5 +1,6 @@
 name: Advanced Medicine
 cost: 4
+supercedes: basic-medicine
 requires: basic-medicine
 description: |
   The character has a number of techniques at their disposal to help those around them. The character can perform any of the following actions by spending a Slow 60 out of combat tending to another (these cannot be performed on the character themself). These can be done as part of a Short Rest.

--- a/camp/tempest/v1/skills/trade/profession-journeyman.yaml
+++ b/camp/tempest/v1/skills/trade/profession-journeyman.yaml
@@ -1,7 +1,7 @@
 name: Profession - Journeyman
 cost: 2
 # TODO(#16): Add tracking to record the income
-supercedes: profession-apprentice
+supersedes: profession-apprentice
 requires: profession-apprentice
 option:
   multiple: false

--- a/camp/tempest/v1/skills/trade/profession-journeyman.yaml
+++ b/camp/tempest/v1/skills/trade/profession-journeyman.yaml
@@ -1,6 +1,7 @@
 name: Profession - Journeyman
 cost: 2
 # TODO(#16): Add tracking to record the income
+supercedes: profession-apprentice
 requires: profession-apprentice
 option:
   multiple: false

--- a/camp/tempest/v1/skills/trade/profession-master.yaml
+++ b/camp/tempest/v1/skills/trade/profession-master.yaml
@@ -1,7 +1,7 @@
 name: Profession - Master
 cost: 3
 # TODO(#16): Add tracking to record the income
-supercedes: profession-journeyman
+supersedes: profession-journeyman
 requires: profession-journeyman
 option:
   multiple: false

--- a/camp/tempest/v1/skills/trade/profession-master.yaml
+++ b/camp/tempest/v1/skills/trade/profession-master.yaml
@@ -1,6 +1,7 @@
 name: Profession - Master
 cost: 3
 # TODO(#16): Add tracking to record the income
+supercedes: profession-journeyman
 requires: profession-journeyman
 option:
   multiple: false

--- a/static/css/print/LICENSE.txt
+++ b/static/css/print/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Christian Oliff
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/static/css/print/README.md
+++ b/static/css/print/README.md
@@ -1,0 +1,29 @@
+[![LICENSE](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/coliff/bootstrap-print-css/master/LICENSE)
+[![GitHub Super-Linter](https://github.com/coliff/bootstrap-print-css/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/marketplace/actions/super-linter)
+[![GitHub Stars](https://img.shields.io/github/stars/coliff/bootstrap-print-css.svg?label=github%20stars)](https://github.com/coliff/bootstrap-print-css)
+[![NPM Version](https://img.shields.io/npm/v/bootstrap-print-css)](https://www.npmjs.com/package/bootstrap-print-css)
+
+# Bootstrap Print CSS 🖨️
+
+Bootstrap 5 no longer includes custom CSS for printing - with the CSS in this project you can add it back.
+
+Note: This should improve the experience when printing, but there are [bugs and inconsistencies](https://github.com/twbs/bootstrap/issues?page=2&q=is%3Aissue+sort%3Aupdated-desc+print) with the way that browsers handle printing so testing is recommended.
+
+## Quick Start
+
+- [Download the latest release](https://github.com/coliff/bootstrap-print-css/)
+- Clone the repo `git clone https://github.com/coliff/bootstrap-print-css.git`
+- Install with [npm](https://www.npmjs.com/package/bootstrap-print-css) `npm install bootstrap-print-css`
+- Install with [yarn](https://yarnpkg.com/package/bootstrap-print-css) `yarn add bootstrap-print-css`
+
+## Usage
+
+You can include the CSS with one of the following:
+
+1. Import the `bootstrap-print.css` to your main CSS. This will mean one less HTTP request compared to loading it separately.
+
+2. Load it as a separate CSS file `<link rel="stylesheet" href="/css/bootstrap-print.min.css" media="print">`
+
+## Credits & Thanks
+
+All credit for the CSS work goes to the HTML5 Boilerplate and Bootstrap teams. I've just copied the [Bootstrap 4 print styles](https://github.com/twbs/bootstrap/blob/v4-dev/scss/_print.scss) and packaged them up for Bootstrap 5.

--- a/static/css/print/bootstrap-print.css
+++ b/static/css/print/bootstrap-print.css
@@ -1,0 +1,72 @@
+@media print {
+  *,
+  *::before,
+  *::after {
+    text-shadow: none !important;
+    box-shadow: none !important;
+  }
+  a {
+    text-decoration: none;
+    color: var(--bs-body-color);
+  }
+  abbr[title]::after {
+    content: " (" attr(title) ")";
+  }
+  pre {
+    white-space: pre-wrap !important;
+  }
+  pre,
+  blockquote {
+    border: 1px solid #adb5bd;
+    page-break-inside: avoid;
+  }
+  tr,
+  img {
+    page-break-inside: avoid;
+  }
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3;
+  }
+  h2,
+  h3 {
+    page-break-after: avoid;
+  }
+  @page {
+    size: a3;
+  }
+  body {
+    min-width: 992px !important;
+  }
+  .container {
+    min-width: 992px !important;
+  }
+  .badge {
+    border: 1px solid #000;
+  }
+  .table {
+    border-collapse: collapse !important;
+  }
+  .table td,
+  .table th {
+    background-color: #fff !important;
+  }
+  .table-bordered th,
+  .table-bordered td {
+    border: 1px solid #dee2e6 !important;
+  }
+  .table-dark {
+    color: inherit;
+  }
+  .table-dark th,
+  .table-dark td,
+  .table-dark thead th,
+  .table-dark tbody + tbody {
+    border-color: #dee2e6;
+  }
+  .avoidbreak {
+    break-inside: avoid;
+  }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,8 +16,17 @@
   {% block css %}
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css" integrity="sha384-EvBWSlnoFgZlXJvpzS+MAUEjvN7+gcCwH+qh7GRFOGgZO0PuwOFro7qPOJnLfe7l" crossorigin="anonymous">
+  <link rel="stylesheet" href="{% static 'css/print/bootstrap-print.css' %}" media="print">
   <link rel="stylesheet" href="{% static 'css/base.css' %}">
   {% endblock css %}
+  <script>
+    window.addEventListener('beforeprint', (event) => {
+      document.documentElement.setAttribute('data-bs-theme', 'light');
+    });
+    window.addEventListener('afterprint', (event) => {
+      document.documentElement.setAttribute('data-bs-theme', 'dark');
+    });
+  </script>
 </head>
 
 <body class="d-flex flex-column h-100"
@@ -25,7 +34,7 @@
       hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
   {% block body %}
   {% has_perm 'game.change_game' user game as can_change_game %}
-  <header>
+  <header class="d-print-none">
     <nav class="navbar navbar-expand-lg bg-body-tertiary">
       <div class="container-fluid">
         <a class="navbar-brand" href="{% url 'home' %}">
@@ -103,7 +112,7 @@
   </header>
 
   {% if messages %}
-  <div id="messages">
+  <div id="messages" class="d-print-none">
     {% for message in messages %}
       <div class="alert alert-{{message.level_tag}} alert-dismissible fade show" role="alert">
         {{message}}
@@ -114,11 +123,11 @@
   </div>
   {% endif %}
 
-  <div id="htmx-alert" hidden class="alert alert-warning sticky-top"></div>
+  <div id="htmx-alert" hidden class="alert alert-warning sticky-top d-print-none"></div>
 
   <main class="flex-shrink-0">
-    <h1>{% block body_title %}{% endblock %}</h1>
     <div class="container">
+      <h1>{% block body_title %}{% endblock %}</h1>
       {% block precontent %}{% endblock %}
     </div>
     <div class="container py-2">
@@ -131,7 +140,7 @@
   {% block extra_body %}
   {% endblock extra_body %}
 
-  <footer class="footer mt-auto py-3">
+  <footer class="footer mt-auto py-3 d-print-none">
     <div class="container">
     {% block footer %}
     {% endblock footer %}


### PR DESCRIPTION
1. There's now a print button on both character sheets and feature detail pages.
2. These pages format themselves better in printing views.
3. The layout of the character sheet has been updated to be a bit more space efficient, when printed or otherwise.
4. Add a concept of a skill chain for things like Forage I, II, III, Apprentice/Journeyman/Greater/Master X, Draconic Heritage I-V, etc. Only the highest level purchased from the chain will appear on your sheet, though the others can be found by following the links back from the skill detail page. If a skill has been superseded but still needs a choice, it isn't hidden. The most common occurrence of this is Socialite granting Profession Apprentice AND Journeyman at once.
