### PR TITLE
Update advanced class requirements and remove training flags

### DIFF
--- a/camp/tempest/v1/classes/advanced-classes/hooligan/hooligan.yaml
+++ b/camp/tempest/v1/classes/advanced-classes/hooligan/hooligan.yaml
@@ -8,7 +8,6 @@ requires:
   - power@2
   - short-weapons
   - light-armor
-flags: flag+hooligan
 level_grants:
   2: hooligan-bonus-spikes
 description: |

--- a/camp/tempest/v1/classes/advanced-classes/ranger/ranger.yaml
+++ b/camp/tempest/v1/classes/advanced-classes/ranger/ranger.yaml
@@ -9,7 +9,6 @@ requires:
   - lore+Nature
   - tracking
   - power@2
-flags: flag+ranger
 level_grants:
   2: ranger-bonus-damage
   4: ranger-bonus-spikes

--- a/camp/tempest/v1/classes/advanced-classes/ringleader/ringleader.yaml
+++ b/camp/tempest/v1/classes/advanced-classes/ringleader/ringleader.yaml
@@ -17,7 +17,6 @@ requires:
       - rumormonger
       - undevoted
       - devotion.advanced
-flags: flag+ringleader
 description: |
   Across the Eyes, there will always be groups who seek to expand their influence. Teams band together under a belt flag, soldiers stand at attention for their superior officer, and crime syndicates take their orders, too. Regardless of morality, political affiliation or creed, it’s common for peoples with aligning purposes to seek leadership as it were and take orders from an elected or self-chosen leader.
 

--- a/camp/tempest/v1/classes/advanced-classes/spellblade/spellblade.yaml
+++ b/camp/tempest/v1/classes/advanced-classes/spellblade/spellblade.yaml
@@ -20,7 +20,6 @@ spells_known:
   3: 3
   4: 4
   5: 5
-flags: flag+spellblade
 requires:
   - level:10
   - spell:2


### PR DESCRIPTION
Remove flags from classes for which training has been accomplished by the building system.

TODO: Missing Shifter and Warden, which are incomplete currently.